### PR TITLE
19 alternate descriptions for images

### DIFF
--- a/comments.html
+++ b/comments.html
@@ -16,7 +16,7 @@
       <p><a href="https://www.onallbands.com/ham-radio-101-what-is-wspr/">Ham Radio 101: What is WSPR? </a></p>
       <div class="container">
         <div class="image">
-          <img src="img/Screenshot_2024-11-07_203455.png" alt="" class="center">
+          <img src="img/Screenshot_2024-11-07_203455.png" alt="On All Bands logo" class="center">
         </div>
         <div class="text">
           <h2>IgorPartola</h2>

--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
       <div class="wrap wrap--front">
         <section class="article article--front_page">
           <div class="wrap wrap--image">
-            <img class="article__image" src="img/Marine-Cyanobacteria_Figure-3.jpg" alt="">
+            <img class="article__image" src="img/Marine-Cyanobacteria_Figure-3.jpg" alt="Grayscale microscopic image of cyanobacteria">
           </div>
           <h2 class="article__headline">
             Newly discovered cyanobacteria could help sequester carbon from oceans and factories
@@ -44,49 +44,49 @@
       <div class="grid">
         <a class="article" href="https://wyss.harvard.edu/news/newly-discovered-cyanobacteria-could-help-sequester-carbon-from-oceans-and-factories/">
           <div class="wrap wrap--image">
-            <img class="article__image" src="img/NLP_article_img.gif" alt="">
+            <img class="article__image" src="img/NLP_article_img.gif" alt="Gif of terminal">
           </div>
           <h2 class="article__headline">Statistical NLP on OpenStreetMap</h2>
         </a>
         <a class="article" href="https://www.yusufaytas.com/subteam-tenets/">
           <div class="wrap wrap--image">
-            <img class="article__image" src="img/subteam-tenets.jpeg" alt="">
+            <img class="article__image" src="img/subteam-tenets.jpeg" alt="Man and woman sitting in meeting together with macbooks">
           </div>
           <h2 class="article__headline">Subteam Tenets</h2>
         </a>
         <a class="article" href="https://www.theverge.com/2024/11/6/24289768/openai-chat-chatgpt-sam-altman-hubspot">
           <div class="wrap wrap--image">
-            <img class="article__image" src="img/openAI.jpg" alt="">
+            <img class="article__image" src="img/openAI.jpg" alt="Open AI logo with pink and purple gradient background">
           </div>
           <h2 class="article__headline">Did OpenAI just spend more than $10 million on a URL?</h2>
         </a>
         <a class="article" href="https://github.com/RamboRogers/greeter">
           <div class="wrap wrap--image">
-            <img class="article__image" src="img/github.png" alt="">
+            <img class="article__image" src="img/github.png" alt="Github logo and title">
           </div>
           <h2 class="article__headline">Show HN: AI Emotion and Recognition for UDM Pro W Webhooks</h2>
         </a>
         <a class="article" href="https://github.com/DefGuard/defguard">
           <div class="wrap wrap--image">
-            <img class="article__image" src="img/github.png" alt="">
+            <img class="article__image" src="img/github.png" alt="Github logo and title">
           </div>
           <h2 class="article__headline">Defguard: 2FA MFA WireGuard Enterprise VPN with SSO, Hardware Keys Management</h2>
         </a>
         <a class="article" href="https://www.triplechecker.com/">
           <div class="wrap wrap--image">
-            <img class="article__image" src="img/triple-checker.jpg" alt="">
+            <img class="article__image" src="img/triple-checker.jpg" alt="Triple checker logo of 3 parallel checkmarks and the title">
           </div>
           <h2 class="article__headline">Show HN: Grammarly for Websites (TripleChecker)</h2>
         </a>
         <a class="article" href="https://www.mixus.ai/landing?redirect_url=https%3A%2F%2Fwww.mixus.ai%2F">
           <div class="wrap wrap--image">
-            <img class="article__image" src="img/mixus.jpg" alt="">
+            <img class="article__image" src="img/mixus.jpg" alt="Mixus logo and title">
           </div>
           <h2 class="article__headline">Multiplayer AI chat with human intelligence</h2>
         </a>
         <a class="article" href="https://github.com/lima-vm/lima/releases/tag/v1.0.0">
           <div class="wrap wrap--image">
-            <img class="article__image" src="img/github.png" alt="">
+            <img class="article__image" src="img/github.png" alt="Github logo and title">
           </div>
           <h2 class="article__headline">Lima v1.0.0</h2>
         </a>

--- a/signup.html
+++ b/signup.html
@@ -11,24 +11,32 @@
   <header>
     <h1>Be Part of the Secrets. Join Now.</h1>
   </header>
+
   <main>
     <section id="signup-page">
       <h2>Sign Up</h2>
       <form id="signup-form" method="get" action="#null" autocomplete="on">
         <label for="first-name" class="form-label">First Name:</label>
         <input type="text" id="first-name" name="first-name" required>
+
         <label for="last-name" class="form-label">Last Name:</label>
         <input type="text" id="last-name" name="last-name" required>
+
         <label for="dob" class="form-label">D.O.B.:</label>
         <input type="date" id="dob" name="dob" required>
+
         <label for="email" class="form-label">Email:</label>
         <input type="email" id="email" name="email" required>
+
         <button type="submit">Enter</button>
       </form>
+
       <p>Already have an account? <a href="submit.html">Log in here</a>.</p>
     </section>
   </main>
+
   <footer></footer>
+
   <script src="js/script.js"></script>
 </body>
 </html>

--- a/signup.html
+++ b/signup.html
@@ -11,32 +11,24 @@
   <header>
     <h1>Be Part of the Secrets. Join Now.</h1>
   </header>
-
   <main>
     <section id="signup-page">
       <h2>Sign Up</h2>
       <form id="signup-form" method="get" action="#null" autocomplete="on">
         <label for="first-name" class="form-label">First Name:</label>
         <input type="text" id="first-name" name="first-name" required>
-
         <label for="last-name" class="form-label">Last Name:</label>
         <input type="text" id="last-name" name="last-name" required>
-
         <label for="dob" class="form-label">D.O.B.:</label>
         <input type="date" id="dob" name="dob" required>
-
         <label for="email" class="form-label">Email:</label>
         <input type="email" id="email" name="email" required>
-
         <button type="submit">Enter</button>
       </form>
-
       <p>Already have an account? <a href="submit.html">Log in here</a>.</p>
     </section>
   </main>
-
   <footer></footer>
-
   <script src="js/script.js"></script>
 </body>
 </html>

--- a/signup.html
+++ b/signup.html
@@ -15,7 +15,7 @@
   <main>
     <section id="signup-page">
       <h2>Sign Up</h2>
-      <form id="signup-form">
+      <form id="signup-form" method="get" action="#null" autocomplete="on">
         <label for="first-name" class="form-label">First Name:</label>
         <input type="text" id="first-name" name="first-name" required>
 

--- a/signup.html
+++ b/signup.html
@@ -15,7 +15,7 @@
   <main>
     <section id="signup-page">
       <h2>Sign Up</h2>
-      <form id="signup-form" method="get" action="#null" autocomplete="on">
+      <form id="signup-form">
         <label for="first-name" class="form-label">First Name:</label>
         <input type="text" id="first-name" name="first-name" required>
 


### PR DESCRIPTION
# Alt Tags for Images

Closes #19 

Alt tags have been added to the following images:

- _marine-cyanobacteria_figure3.jpg_: Grayscale microscopic image of cyanbacteria
- _nlp_article_img.gif_: Gif of terminal
- _subteam-tenets.jpeg_: Man and woman sitting in meeting together with macbooks
- _openAI.jpg_: Open AI logo with pink and purple gradient background
- _github.png_: Github logo and title
- _triple-checker.jpg_: Triple checker logo of 3 parallel checkmarks and the title
- _mixus.jpg_: Mixus logo and title
- _screenshot_2024-11-07_203455.png_: On All Bands logo

## HTML Validator

- ### index.html
![image](https://github.com/user-attachments/assets/2bd031a2-552a-4c79-9ab1-d7a42bf2449a)

- ### comments.html
![image](https://github.com/user-attachments/assets/c29c42bb-8854-4121-8672-812b069b8353)

