### PR TITLE
Update font family for news page

### DIFF
--- a/css/screen.css
+++ b/css/screen.css
@@ -1,3 +1,22 @@
+@import url('https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Press+Start+2P&family=Tomorrow:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Figtree:ital,wght@0,300..900;1,300..900&family=Press+Start+2P&family=Tomorrow:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap');
+
+@font-face {
+  font-family: 'Press Start 2P';
+  src: url('https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap');
+}
+
+@font-face {
+  font-family: 'Tomorrow';
+  src: url('https://fonts.googleapis.com/css2?family=Press+Start+2P&family=Tomorrow:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap')
+}
+
+@font-face {
+  font-family: 'Figtree';
+  src: url('https://fonts.googleapis.com/css2?family=Figtree:ital,wght@0,300..900;1,300..900&family=Press+Start+2P&family=Tomorrow:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap');
+}
+
 a {
     text-decoration: none;
   }
@@ -59,6 +78,7 @@ a {
   }
   
   .article__headline {
+    font-family: 'Figtree', sans-serif;
     color: black;
     font-size: 1em;
     line-height: 1.2em;
@@ -125,6 +145,7 @@ a {
   }
   
   .navigation__option {
+    font-family: 'Tomorrow', sans-serif;
     font-size: 1em;
     line-height: 1.2em;
     color: rgb(255, 102, 0);
@@ -156,6 +177,8 @@ a {
   }
   
   .title {
+    font-family: "Press Start 2P", sans-serif;
+    margin-top: 0.5em;
     margin-bottom: 0.5em;
     font-size: 2.168em;
     line-height: 1.2em;
@@ -167,14 +190,15 @@ a {
   }
   
   .trending__title {
+    font-family: 'Tomorrow', Georgia, 'Times New Roman', Times, serif;
     color: black;
-    opacity: 0.50;
+    opacity: 0.60;
   }
   
   .trending__repo {
+    font-family: 'Figtree', Arial, Helvetica, sans-serif;
     color: black;
     opacity: 0.40;
-    font-weight: 700;
     text-decoration: none;
   }
   


### PR DESCRIPTION
# Update Font Family for News Page

Closes #25 

## Changes

- Title font family is 'Press Start 2P', sans-serif
- Navigation font family is 'Tomorrow', sans-seif
- Trending repo font family is 'Figtree', Arial, Helvetica, sans-serif
- Trending title repo is 'Tomorrow', Georgia, 'Times New Roman', Times, serif
- Article Headline font family is 'Figtree', sans-serif

![image](https://github.com/user-attachments/assets/dca999a9-a5b0-46c3-871d-60d53cbcd148)

## Validation

### HTML Validation

![image](https://github.com/user-attachments/assets/172c7c6e-34c8-4b15-8ef6-efa15eb5e45f)

### CSS Validation

![image](https://github.com/user-attachments/assets/4c62df51-951c-43e0-9683-c0b78b7abcb6)
